### PR TITLE
Added finger tracking

### DIFF
--- a/Input/FingerCurler.cs
+++ b/Input/FingerCurler.cs
@@ -1,0 +1,180 @@
+﻿using LCVR.Networking;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.XR;
+using UnityEngine.XR;
+
+using CommonUsages = UnityEngine.XR.CommonUsages;
+using InputDevice = UnityEngine.XR.InputDevice;
+
+namespace LCVR.Input
+{
+    public class FingerCurler
+    {
+        public class Finger
+        {
+            public Transform bone01;
+            public Transform bone02;
+
+            public float curl;
+
+            private readonly Quaternion bone01Rotation;
+            private readonly Quaternion bone02Rotation;
+
+            private readonly float sign;
+
+            public Finger(Transform root, bool isLeft, Vector3 firstRotation, Vector3 secondRotation)
+            {
+                bone01 = root;
+                bone02 = root.GetChild(0);
+
+                bone01Rotation = Quaternion.Euler(firstRotation);
+                bone02Rotation = Quaternion.Euler(secondRotation);
+
+                sign = isLeft ? 1f : -1f;
+            }
+
+            public void Update()
+            {
+                float angle = Mathf.Lerp(0f, 80f, curl);
+
+                bone01.localRotation = Quaternion.AngleAxis(-angle, Vector3.right) * bone01Rotation;
+                bone02.localRotation = Quaternion.AngleAxis(angle * sign, Vector3.forward) * bone02Rotation;
+            }
+        }
+
+        public class Thumb
+        {
+            public Transform bone01;
+            public Transform bone02;
+
+            public float curl;
+
+            private readonly Quaternion bone01Rotation;
+            private readonly Quaternion bone02Rotation;
+
+            private readonly float sign;
+
+            public Thumb(Transform root, bool isLeft, Vector3 firstRotation, Vector3 secondRotation)
+            {
+                bone01 = root;
+                bone02 = root.GetChild(0);
+
+                var offset = Quaternion.AngleAxis(30f * sign, Vector3.up) * Quaternion.AngleAxis(-30f, Vector3.right);
+
+                bone01Rotation = offset * Quaternion.Euler(firstRotation);
+                bone02Rotation = Quaternion.Euler(secondRotation);
+
+                sign = isLeft ? 1f : -1f;
+            }
+
+            public void Update()
+            {
+                float angle = Mathf.Lerp(0f, 80f, curl);
+
+                bone01.localRotation = bone01Rotation;
+                bone02.localRotation = Quaternion.AngleAxis(-angle, Vector3.right) * bone02Rotation;
+            }
+        }
+
+        public Thumb thumbFinger;
+        public Finger indexFinger;
+        public Finger middleFinger;
+        public Finger ringFinger;
+        public Finger pinkyFinger;
+
+        public FingerCurler(Transform hand, bool isLeft)
+        {
+            if (isLeft)
+            {
+                thumbFinger = new Thumb(hand.Find($"finger1.L"), isLeft, new Vector3(35f, -90f, 0f), new Vector3(-25f, 0f, 3f));
+                indexFinger = new Finger(hand.Find($"finger2.L"), isLeft, new Vector3(5f, -90f, 0f), new Vector3(3f, -3f, 33f));
+                middleFinger = new Finger(hand.Find($"finger3.L"), isLeft, new Vector3(-182f, 90f, -176f), new Vector3(1f, -5f, 22f));
+                ringFinger = new Finger(hand.Find($"finger4.L"), isLeft, new Vector3(186f, 90f, 177f), new Vector3(6f, -3f, 29f));
+                pinkyFinger = new Finger(hand.Find($"finger5.L"), isLeft, new Vector3(183f, 80f, 176f), new Vector3(-17f, 8f, 27f));
+            }
+            else
+            {
+                thumbFinger = new Thumb(hand.Find($"finger1.R"), isLeft, new Vector3(143f, -90f, -180f), new Vector3(-26f, 0f, -5f));
+                indexFinger = new Finger(hand.Find($"finger2.R"), isLeft, new Vector3(-193f, -90f, 176f), new Vector3(-9f, 0f, -21f));
+                middleFinger = new Finger(hand.Find($"finger3.R"), isLeft, new Vector3(-186f, -90f, 180f), new Vector3(-6f, 0f, -24f));
+                ringFinger = new Finger(hand.Find($"finger4.R"), isLeft, new Vector3(180f, -90f, -177f), new Vector3(-9f, 0f, -25f));
+                pinkyFinger = new Finger(hand.Find($"finger5.R"), isLeft, new Vector3(182f, -90f, -168f), new Vector3(-13f, 3f, -33f));
+            }
+        }
+
+        public DNet.Fingers GetCurls()
+        {
+            return new DNet.Fingers()
+            {
+                thumb = thumbFinger.curl,
+                index = indexFinger.curl,
+                middle = middleFinger.curl,
+                ring = ringFinger.curl,
+                pinky = pinkyFinger.curl,
+            };
+        }
+
+        public void SetCurls(DNet.Fingers fingers)
+        {
+            thumbFinger.curl = fingers.thumb;
+            indexFinger.curl = fingers.index;
+            middleFinger.curl = fingers.middle;
+            ringFinger.curl = fingers.ring;
+            pinkyFinger.curl = fingers.pinky;
+        }
+
+        public virtual void Update()
+        {
+            thumbFinger.Update();
+            indexFinger.Update();
+            middleFinger.Update();
+            ringFinger.Update();
+            pinkyFinger.Update();
+        }
+    }
+
+    public class VRFingerCurler : FingerCurler
+    {
+        public InputDevice device;
+
+        public VRFingerCurler(Transform hand, bool isLeft) : base(hand, isLeft)
+        {
+            XRNode node = isLeft ? XRNode.LeftHand : XRNode.RightHand;
+
+            device = InputDevices.GetDeviceAtXRNode(node);
+        }
+
+        public override void Update()
+        {
+            UpdateCurls();
+
+            base.Update();
+        }
+
+        private void UpdateCurls()
+        {
+            device.TryGetFeatureValue(CommonUsages.primaryTouch, out bool primaryTouch);
+            device.TryGetFeatureValue(CommonUsages.secondaryTouch, out bool secondaryTouch);
+
+            thumbFinger.curl = primaryTouch || secondaryTouch ? 1f : 0f;
+
+            if (device.TryGetFeatureValue(CommonUsages.trigger, out float trigger))
+            {
+                 indexFinger.curl = trigger;
+            }
+
+            if (device.TryGetFeatureValue(CommonUsages.grip, out float grip))
+            {
+                middleFinger.curl = grip;
+                ringFinger.curl = grip;
+                pinkyFinger.curl = grip;
+            }
+        }
+    }
+}

--- a/Networking/DNet.cs
+++ b/Networking/DNet.cs
@@ -169,13 +169,57 @@ namespace LCVR.Networking
             player.UpdateCameraFloorOffset(offset);
         }
 
+        public struct Fingers
+        {
+            public const int ByteCount = 5;
+
+            public float thumb;
+            public float index;
+            public float middle;
+            public float ring;
+            public float pinky;
+
+            public readonly byte[] Serialize()
+            {
+                using var mem = new MemoryStream();
+                using var bw = new BinaryWriter(mem);
+
+                bw.Write((byte)(thumb * 255f));
+                bw.Write((byte)(index * 255f));
+                bw.Write((byte)(middle * 255f));
+                bw.Write((byte)(ring * 255f));
+                bw.Write((byte)(pinky * 255f));
+
+                return mem.ToArray();
+            }
+
+            public static Fingers Deserialize(byte[] raw)
+            {
+                using var mem = new MemoryStream(raw);
+                using var br = new BinaryReader(mem);
+
+                var fingers = new Fingers
+                {
+                    thumb = ((float)br.ReadByte()) / 255f,
+                    index = ((float)br.ReadByte()) / 255f,
+                    middle = ((float)br.ReadByte()) / 255f,
+                    pinky = ((float)br.ReadByte()) / 255f,
+                    ring = ((float)br.ReadByte()) / 255f,
+                };
+
+                return fingers;
+            }
+        }
+
         public struct Rig
         {
             public Vector3 rightHandPosition;
             public Vector3 rightHandEulers;
+            public Fingers rightHandFingers;
 
             public Vector3 leftHandPosition;
             public Vector3 leftHandEulers;
+            public Fingers leftHandFingers;
 
             public Vector3 cameraEulers;
             public Vector3 cameraPosAccounted;
@@ -196,6 +240,8 @@ namespace LCVR.Networking
                 bw.Write(rightHandEulers.y);
                 bw.Write(rightHandEulers.z);
 
+                bw.Write(rightHandFingers.Serialize());
+
                 bw.Write(leftHandPosition.x);
                 bw.Write(leftHandPosition.y);
                 bw.Write(leftHandPosition.z);
@@ -203,6 +249,8 @@ namespace LCVR.Networking
                 bw.Write(leftHandEulers.x);
                 bw.Write(leftHandEulers.y);
                 bw.Write(leftHandEulers.z);
+
+                bw.Write(leftHandFingers.Serialize());
 
                 bw.Write(cameraEulers.x);
                 bw.Write(cameraEulers.y);
@@ -226,8 +274,10 @@ namespace LCVR.Networking
                 {
                     rightHandPosition = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
                     rightHandEulers = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
+                    rightHandFingers = Fingers.Deserialize(br.ReadBytes(Fingers.ByteCount)),
                     leftHandPosition = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
                     leftHandEulers = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
+                    leftHandFingers = Fingers.Deserialize(br.ReadBytes(Fingers.ByteCount)),
                     cameraEulers = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
                     cameraPosAccounted = new Vector3(br.ReadSingle(), 0, br.ReadSingle()),
                     isCrouching = br.ReadBoolean(),

--- a/Networking/VRNetPlayer.cs
+++ b/Networking/VRNetPlayer.cs
@@ -1,5 +1,6 @@
 ﻿using GameNetcodeStuff;
 using LCVR.Assets;
+using LCVR.Input;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
@@ -21,6 +22,9 @@ namespace LCVR.Networking
 
         public Transform leftItemHolder;
         public Transform rightItemHolder;
+
+        public FingerCurler leftFingerCurler;
+        public FingerCurler rightFingerCurler;
 
         public Transform camera;
 
@@ -93,6 +97,10 @@ namespace LCVR.Networking
             leftItemHolder.localPosition = new Vector3(0.018f, 0.045f, -0.042f);
             leftItemHolder.localEulerAngles = new Vector3(360f - 356.3837f, 357.6979f, 0.1453f);
 
+            // Set up finger curlers
+            rightFingerCurler = new FingerCurler(rightHandParent, false);
+            leftFingerCurler = new FingerCurler(leftHandParent, true);
+
             // Store IK constraint data
             leftLegConstraint = gameObject.Find("ScavengerModel/metarig/Rig 1/LeftLeg").GetComponent<TwoBoneIKConstraint>();
             rightLegConstraint = gameObject.Find("ScavengerModel/metarig/Rig 1/RightLeg").GetComponent<TwoBoneIKConstraint>();
@@ -131,6 +139,17 @@ namespace LCVR.Networking
 
             rightHandTarget.position = rightHandVRTarget.position;
             rightHandTarget.rotation = rightHandVRTarget.rotation;
+        }
+
+        private void LateUpdate()
+        {
+            // Update tracked finger curls after animator update
+            leftFingerCurler?.Update();
+
+            if (!playerController.isHoldingObject)
+            {
+                rightFingerCurler?.Update();
+            }
         }
 
         private IEnumerator RebuildRig()
@@ -186,9 +205,11 @@ namespace LCVR.Networking
         {
             leftController.localPosition = rig.leftHandPosition;
             leftController.localEulerAngles = rig.leftHandEulers;
+            leftFingerCurler?.SetCurls(rig.leftHandFingers);
 
             rightController.localPosition = rig.rightHandPosition;
             rightController.localEulerAngles = rig.rightHandEulers;
+            rightFingerCurler?.SetCurls(rig.rightHandFingers);
 
             camera.transform.eulerAngles = rig.cameraEulers;
             cameraPosAccounted = rig.cameraPosAccounted;

--- a/Player/VRPlayer.cs
+++ b/Player/VRPlayer.cs
@@ -66,6 +66,9 @@ namespace LCVR.Player
         public Transform leftHandRigTransform;
         public Transform rightHandRigTransform;
 
+        public VRFingerCurler leftFingerCurler;
+        public VRFingerCurler rightFingerCurler;
+
         private GameObject leftHandVRTarget;
         private GameObject rightHandVRTarget;
 
@@ -204,6 +207,10 @@ namespace LCVR.Player
             leftItemHolder.SetParent(leftHandTarget, false);
             leftItemHolder.localPosition = new Vector3(0.018f, 0.045f, -0.042f);
             leftItemHolder.localEulerAngles = new Vector3(360f - 356.3837f, 357.6979f, 0.1453f);
+
+            // Set up finger curlers
+            rightFingerCurler = new VRFingerCurler(rightHandTarget, false);
+            leftFingerCurler = new VRFingerCurler(leftHandTarget, true);
 
             StartCoroutine(RebuildRig());
 
@@ -468,9 +475,11 @@ namespace LCVR.Player
             {
                 leftHandPosition = leftController.transform.localPosition,
                 leftHandEulers = leftController.transform.localEulerAngles,
+                leftHandFingers = leftFingerCurler.GetCurls(),
 
                 rightHandPosition = rightController.transform.localPosition,
                 rightHandEulers = rightController.transform.localEulerAngles,
+                rightHandFingers = rightFingerCurler.GetCurls(),
 
                 cameraEulers = mainCamera.transform.eulerAngles,
                 cameraPosAccounted = cameraPosAccounted,
@@ -486,6 +495,14 @@ namespace LCVR.Player
             StartOfRound.Instance.playerLookMagnitudeThisFrame = (angles - lastFrameHMDRotation).magnitude * Time.deltaTime;
 
             lastFrameHMDRotation = angles;
+
+            // Update tracked finger curls after animator update
+            leftFingerCurler?.Update();
+
+            if (!playerController.isHoldingObject)
+            {
+                rightFingerCurler?.Update();
+            }
         }
 
         public void OnDeath()


### PR DESCRIPTION
Makes grip, trigger, and the A/B buttons affect the player model's fingers.
Sends finger curls with one byte per finger.
When holding an object, the right hand stops tracking fingers and uses the grab pose.
Does not currently have individual finger support for index controllers as that would require importing the XRHand package and I didn't feel like doing that, but could easily add support in the future.
![fingers](https://github.com/DaXcess/LCVR/assets/68288964/840e1480-7ab6-4ba3-8f58-57e747f332a9)

Tested on Valve Index with Index Controllers.