### PR TITLE
Add modifier input support

### DIFF
--- a/Input/Actions.cs
+++ b/Input/Actions.cs
@@ -20,6 +20,10 @@ namespace LCVR.Input
         public static InputAction LeftHand_Rotation;
         public static InputAction LeftHand_TrackingState;
 
+        public static InputAction Left_Modifier;
+        public static InputAction Right_Modifier;
+
+
         public readonly static InputActionAsset VRInputActions = InputActionAsset.FromJson(Properties.Resources.vr_inputs);
         public readonly static InputActionAsset LCInputActions = InputActionAsset.FromJson(Properties.Resources.lc_inputs);
 
@@ -38,6 +42,10 @@ namespace LCVR.Input
             LeftHand_Position = VRInputActions.FindAction("Left Hand/Position");
             LeftHand_Rotation = VRInputActions.FindAction("Left Hand/Rotation");
             LeftHand_TrackingState = VRInputActions.FindAction("Left Hand/Tracking State");
+
+            // Find input bindings for modifiers in the VR Input Actions
+            Left_Modifier = VRInputActions.FindAction("Left Hand/Modifier");
+            Right_Modifier = VRInputActions.FindAction("Right Hand/Modifier");
 
             LCInputActions.Enable();
             VRInputActions.Enable();
@@ -59,6 +67,9 @@ namespace LCVR.Input
 
                 var vr = client.DownloadString($"https://raw.githubusercontent.com/DaXcess/LCVR-Controller-Profiles/main/{profile}/lcvr_vr_inputs.json");
                 var lc = client.DownloadString($"https://raw.githubusercontent.com/DaXcess/LCVR-Controller-Profiles/main/{profile}/lcvr_lc_inputs.json");
+
+                // Log success to load the profile
+                Logger.LogInfo($"Loaded controller profile: {profile}");
 
                 return (InputActionAsset.FromJson(vr), InputActionAsset.FromJson(lc));
             }

--- a/LCVR.csproj
+++ b/LCVR.csproj
@@ -6,7 +6,7 @@
     <Description>Collecting Scrap in VR</Description>
     <Version>1.0.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Title>LethalCompanyVR</Title>
   </PropertyGroup>
 

--- a/LCVR/Config.cs
+++ b/LCVR/Config.cs
@@ -27,6 +27,29 @@ namespace LCVR
         public ConfigEntry<float> MovementSprintToggleCooldown { get; } = file.Bind("Input", "MovementSprintToggleCooldown", 1f, new ConfigDescription("The amount of seconds that you need to stand still for sprint to be toggled off automatically. Requires sprint toggle to be enabled.", new AcceptableValueRange<float>(0, 60)));
         public ConfigEntry<string> ControllerBindingsOverrideProfile { get; } = file.Bind("Input", "ControllerBindingsOverrideProfile", "", "Specify the name of a controler profile you would like to use. Keep empty to use the built-in controller profiles. You can find a list of available controller profiles on https://github.com/DaXcess/LCVR-Controller-Profiles");
 
+
+        // Advanced input configuration
+
+        public ConfigEntry<bool> EnableModifierBindings { get; } = file.Bind("Advanced Input", "EnableModifierBindings", false, "Enable or disable modifiers groups in the input");
+
+        // A config entry to let the user list all actions names to disable if the left modifier is pressed, separated by a comma
+        public ConfigEntry<string> LeftModifierDisableActions { get; } = file.Bind("Advanced Input", "LeftModifierDisableActions", "", "A comma separated list of actions to disable when the left modifier is pressed. Requires modifier bindings to be enabled.");
+        public string[] LeftModifierDisableActionsList => LeftModifierDisableActions.Value.Split(',');
+
+        // A config entry to let the user list all actions names to enable if the left modifier is pressed, separated by a comma
+        public ConfigEntry<string> LeftModifierEnableActions { get; } = file.Bind("Advanced Input", "LeftModifierEnableActions", "", "A comma separated list of actions to enable when the left modifier is pressed. Requires modifier bindings to be enabled.");
+        public string[] LeftModifierEnableActionsList => LeftModifierEnableActions.Value.Split(',');
+
+
+        // A config entry to let the user list all actions names to disable if the right modifier is pressed, separated by a comma
+        public ConfigEntry<string> RightModifierDisableActions { get; } = file.Bind("Advanced Input", "RightModifierDisableActions", "", "A comma separated list of actions to disable when the right modifier is pressed. Requires modifier bindings to be enabled.");
+        public string[] RightModifierDisableActionsList => RightModifierDisableActions.Value.Split(',');
+
+        // A config entry to let the user list all actions names to enable if the right modifier is pressed, separated by a comma
+        public ConfigEntry<string> RightModifierEnableActions { get; } = file.Bind("Advanced Input", "RightModifierEnableActions", "", "A comma separated list of actions to enable when the right modifier is pressed. Requires modifier bindings to be enabled.");
+        public string[] RightModifierEnableActionsList => RightModifierEnableActions.Value.Split(',');
+
+
         public TurnProviderOption TurnProvider
         {
             get

--- a/README.md
+++ b/README.md
@@ -10,101 +10,22 @@ The mod is powered by Unity's OpenXR plugin and is thereby compatible with a wid
 
 LCVR is compatible with multiplayer and works seamlessly with VR players and Non-VR players in the same lobby. Running this mod without having a VR headset will allow you to see the arm and head movements of any VR players in the same lobby, all while still being compatible with vanilla clients (even if the host is using no mods at all).
 
-### Discord Server
 
-Facing issues, have some mod (in)compatibility to report or just want to hang out?
+## Modifier Support
 
-You can join the [LCVR Discord Server](https://discord.gg/2DxNgpPZUF)!
+This fork extends LCVR by introducing support for modifiers in the bindings. Modifiers allow for more complex and customizable actions based on different conditions.
+To use this feature you will have to edit the `io.daxcess.lcvr.cfg` config file with these following parameters under the `Advanced Input` category:
+| Setting name  | Type          |  Default value | Description                                                                              |
+| ------------- | ------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| EnableModifierBindings | Boolean | false       | Enable or disable modifiers support in the input                                         |
+| LeftModifierDisableActions | String |          | A comma separated list of actions to disable when the left modifier is pressed. Requires modifier bindings to be enabled. |
+| LeftModifierEnableActions | String |          | A comma separated list of actions to enable when the left modifier is pressed. Requires modifier bindings to be enabled. |
+| RightModifierDisableActions | String |          | A comma separated list of actions to disable when the right modifier is pressed. Requires modifier bindings to be enabled. |
+| RightModifierEnableActions | String |          | A comma separated list of actions to enable when the right modifier is pressed. Requires modifier bindings to be enabled. |
 
-# Compatibility
+When using quest2 profile from [this repositery]([link-to-other-repo](https://github.com/EliasVilld/LCVR-Controller-Profiles/tree/main)). Use the providen settings.
 
-LCVR should be fully compatible with [MoreCompany](https://github.com/notnotnotswipez/MoreCompany) and has first class compatibility support from this mod. At the time of writing there are no other mods that have first class compatibility support, however lots of them are compatible out of the box. You can find a compatibility sheet [here](https://docs.google.com/spreadsheets/d/1mSulrvMkQFtjF_BWDeSfGz9rm3UWKMywmUP1yhcgCGo/edit?usp=sharing).
+### External Binding Profile
 
-# Using the mod
+For an enhanced experience, we recommend using this fork in conjunction with the binding profile available `quest2` in [this repositery]([link-to-other-repo](https://github.com/EliasVilld/LCVR-Controller-Profiles/tree/main)). The external binding profile provides additional configurations and presets designed to work seamlessly with LCVR and its new modifier support.
 
-Once you have installed LCVR via your preferred method, you can now start the game. If this is the first time running the game with the mod, you will notice a warning on the first main menu when the game starts up, which is telling you to restart the game if you want to play in VR. If you are using the mod without VR, you can ignore this warning and continue. If you are using the mod **with** VR, restart your game, and VR will be initialized correctly.
-
-## Configuring the mod
-
-Before starting the game, you can make changes to the configuration file to streamline your VR experience. If you are using r2modman or Thunderstore Mod Manager <sub><sup>(then please switch to r2modman)</sup></sub>, then you can use their built in configuration editor to make the changes you desire.
-
-If you are not using a mod manager, then you can find the configuration inside `BepInEx/config/io.daxcess.lcvr.cfg`.
-
-## Navigating the main menu
-
-The main menu is controlled by ray interactors. You can use any controller to point towards any UI element and click using the trigger button on the corresponding controller. The only thing that has been changed on the main menu by the mod is that the keybinds settings have been disabled, since these have been hijacked by the mod.
-
-## Basic controls
-
-> For a list of all keybinds, check out [KEYBINDS.md](KEYBINDS.md)
-
-Once you are in game, you can move around by using the left joystick. You can use the right joystick (left/right) for snap/smooth turning (if enabled) and switching inventory slot (up/down).
-
-To sprint, press the left joystick button.
-
-To crouch, press the right joystick button.
-
-For more keybinds, check out [KEYBINDS.md](KEYBINDS.md).
-
-## The Terminal
-
-Since in VR you don't have access to a keyboard (under normal circumstances), the mod displays a virtual keyboard when you enter the terminal. You can use this keyboard to interact with the terminal like you would on PC.
-
-This keyboard currently features two macros: A confirm and deny button. When pressed, these respectively send "CONFIRM" and "DENY" to the terminal. This makes it easier to switch moons and purchase items since you won't have to input this text every time.
-
-You can exit the terminal by pressing the pause button or my clicking on the close button on the terminal keyboard.
-
-## Spectating
-
-When you die, you'll be sent to a black void with a screen in front of you (not unlike the main menu), which is where you will live out the rest of the day. You can pivot the spectator camera by using the right controller's joystick.
-
-To spectate the next player, you can utilise the right trigger button. To vote to leave early, use the left trigger button.
-
-## VR additions
-
-This mod in addition to adding VR and motion controls, also adds a few special interactions that you can perform in VR. At the time of writing, these currently are: Spray paint shaking and shovel/sign swinging.
-
-The spray paint shaking is pretty simple: When holding the spray paint item, you can physically shake it to shake the can in the game. You can also still use the secondary interact button to shake the can.
-
-If you are holding a shovel or a sign, you'll notice that you are holding it in two hands. If you now swing the shovel over your shoulder, and then forward with enough force, the mod will actually damage entities (or players) that are in front of you.
-
-# Install from source
-
-> The easiest way to install the mod is by downloading it from Thunderstore. You only need to follow these steps if you are planning on installing the mod by building the source code and without a mod manager.
-
-To install the mod from the source code, you will first have to compile the mod. Instructions for this are available in [COMPILING.md](COMPILING.md).
-
-Next up you'll need to grab a copy of some **Runtime Dependencies**. You can either grab these from [one of the releases](https://github.com/DaXcess/LCVR/releases), or if you truly want the no hand holding experience, you can retrieve them from a Unity project.
-
-## Retrieving Runtime Dependencies from a Unity Project
-
-> You can skip this part if you have taken the runtime dependencies from the releases page.
-
-First of all start by installing Unity 2022.3.9f1, which is the Unity version that Lethal Company uses. Once you have installed the editor, create a new Unity project. If you are planning on adding prefabs to the mod, use the HDRP template and add the XR modules via the HDRP helper or by manually installing the Unity OpenXR plugins (Google is your friend). Otherwise you can just use the VR template.
-
-Make sure you set the scripting backend to Mono, and not to Il2Cpp (Unity will warn you when you try to compile a VR game with Il2Cpp enabled). You can now build your dummy game. Once the game is built you can navigate to it's `<Project Name>_Data/Managed` directory. There you will need to extract the following files:
-
-- UnityEngine.SpatialTracking.dll
-- Unity.XR.CoreUtils.dll
-- Unity.XR.Interaction.Toolkit.dll
-- Unity.XR.Management.dll
-- Unity.XR.OpenXR.dll
-
-And from the `<Project Name>_Data/Plugins/x86_64` directory:
-
-- openxr_loader.dll
-- UnityOpenXR.dll
-
-## Install BepInEx
-
-BepInEx is the modloader that LCVR uses to mod the game. You can download BepInEx from their [GitHub Releases](https://github.com/BepInEx/BepInEx/releases) (LCVR currently targets BepInEx 5.4.22).
-
-To install BepInEx, you can follow their [Installation Gude](https://docs.bepinex.dev/articles/user_guide/installation/index.html#installing-bepinex-1).
-
-## Installing the mod
-
-Once BepInEx has been installed and run at least once, you can start installing the mod.
-
-First of all, in the `BepInEx/plugins` folder, create a new folder called `LCVR` (doesn't have to be named that specifically, but makes identification easier). Inside this folder, place the `LCVR.dll` file that was generated during the [COMPILING.md](COMPILING.md) steps.
-
-After this has been completed, create a new directory called `RuntimeDeps` (has to be named exactly that) inside of the `LCVR` folder. Inside this folder you will need to put the DLLs that you have retrieved during the [Retrieving Runtime Depenencies](#retrieving-runtime-dependencies-from-a-unity-project) step. You can now run the game with LCVR installed.


### PR DESCRIPTION
This pull request adds support for input modifiers.

The aim is to enable/disable actions if you hold an input. Considering we can't edit the game itself to change the logic of the input, we disable a part of the actions.

For example, in my use case (for this controller profile for quest2; [link](https://github.com/EliasVilld/LCVR-Controller-Profiles) ), I've made it so that if you hold the controller's right handle, it disables the grab/interact/switchItem actions, allowing you to use the build mode actions.

See below the input mapping for this profile :
![image_2024-01-15_224652680](https://github.com/DaXcess/LCVR/assets/82938532/9a3b4753-4ae1-4052-a682-e69ba9f36bdf)


I've added a configuration parameter to allow the user to enable or disable this support, and allow them to specify which actions should be enabled/disabled when using the modifier.

The main aim is to extend the mapping to VR controllers (I've only tested it on Quest 2, but it should be flexible enough to be used on other controllers). 