### PR TITLE
Decouple body from head rotation

### DIFF
--- a/Player/VRPlayer.cs
+++ b/Player/VRPlayer.cs
@@ -434,12 +434,12 @@ namespace LCVR.Player
             //Logger.LogDebug($"{transform.position} {xrOrigin.position} {leftHandVRTarget.transform.position} {rightHandVRTarget.transform.position} {cameraFloorOffset} {cameraPosAccounted}");
 
             if ((xrOrigin.position - lastOriginPos).sqrMagnitude > sqrMoveThreshold) // player moved
-                // Rotate player sharply but still smoothly
-                RotatePlayer(turnWeightSharp);
+                // Rotate body sharply but still smoothly
+                TurnBodyToCamera(turnWeightSharp);
 
             else if (!playerController.inSpecialInteractAnimation && GetBodyToCameraAngle() is var angle && angle > turnAngleThreshold)
-                // Rotate player as smoothly as possible but prevent 180 deg head twists on quick rotations
-                RotatePlayer(turnWeightSharp * Mathf.InverseLerp(turnAngleThreshold, 170f, angle));
+                // Rotate body as smoothly as possible but prevent 360 deg head twists on quick rotations
+                TurnBodyToCamera(turnWeightSharp * Mathf.InverseLerp(turnAngleThreshold, 170f, angle));
 
             if (!playerController.inSpecialInteractAnimation)
                 lastFrameHMDPosition = mainCamera.transform.localPosition;
@@ -627,7 +627,7 @@ namespace LCVR.Player
             mainCamera.enabled = true;
         }
 
-        private void RotatePlayer(float turnWeight)
+        private void TurnBodyToCamera(float turnWeight)
         {
             var newRotation = Quaternion.Euler(transform.rotation.eulerAngles.x, mainCamera.transform.eulerAngles.y, transform.rotation.eulerAngles.z);
             transform.rotation = Quaternion.Lerp(transform.rotation, newRotation, Time.deltaTime * turnWeight);

--- a/Player/VRPlayer.cs
+++ b/Player/VRPlayer.cs
@@ -436,7 +436,6 @@ namespace LCVR.Player
             if ((xrOrigin.position - lastOriginPos).sqrMagnitude > sqrMoveThreshold) // player moved
                 // Rotate body sharply but still smoothly
                 TurnBodyToCamera(turnWeightSharp);
-
             else if (!playerController.inSpecialInteractAnimation && GetBodyToCameraAngle() is var angle && angle > turnAngleThreshold)
                 // Rotate body as smoothly as possible but prevent 360 deg head twists on quick rotations
                 TurnBodyToCamera(turnWeightSharp * Mathf.InverseLerp(turnAngleThreshold, 170f, angle));


### PR DESCRIPTION
Small set of changes to make the horizontal camera movement not move the entire body at all times. This allows for more natural gestures where you look to the side or shake your head.

The body rotates if:
1. the player physically moves, or
2. the player camera rotates beyond a specified threshold.

There are some things still left to do:
- [x] Turning should be smoothed out.
- [ ] Camera rotation-to-body threshold should probably be configurable.
- [ ] I kinda want to make special animations (mostly using the computer) work with this, so other players can see you look around. I think the animation overrides the head movement but haven't looked into it yet.

Tested online:

https://github.com/DaXcess/LCVR/assets/16500675/54198c2d-e225-47c9-a469-e2df054ba58d
