### PR TITLE
Mimics compatibility: Offset mimic interact UI to be in the correct position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.user
 
 /.vs
+/.idea
 /obj
 /bin
 /Libs/Assembly-CSharp.dll

--- a/Compatibility/Mimics/Patches.cs
+++ b/Compatibility/Mimics/Patches.cs
@@ -1,0 +1,27 @@
+﻿using HarmonyLib;
+using LCVR.Patches;
+using LCVR.UI;
+using Mimics;
+using UnityEngine;
+
+namespace LCVR.Compatibility
+{
+    [LCVRPatch(dependency: "Mimics")]
+    [HarmonyPatch]
+    internal static class MimicUIPatches
+    {
+        [HarmonyPatch(typeof(RoundManager), "SetExitIDs")]
+        [HarmonyPostfix]
+        [HarmonyAfter(["x753.Mimics"])]
+        private static void AssignInteractTriggerOffset()
+        {
+            // The difference between the original fire door and the mimic 
+            var offset = new Vector3(0, 1.6307f, -0.35f);
+            
+            foreach (var mimicDoor in MimicDoor.allMimics)
+            {
+                mimicDoor.interactTrigger.gameObject.AddComponent<InteractCanvasPositionOffset>().offset = offset;
+            }
+        }
+    }
+}

--- a/Compatibility/Mimics/Patches.cs
+++ b/Compatibility/Mimics/Patches.cs
@@ -10,18 +10,16 @@ namespace LCVR.Compatibility
     [HarmonyPatch]
     internal static class MimicUIPatches
     {
+        // The difference between the original fire door and the mimic 
+        private static readonly Vector3 doorInteractorOffset = new(0, 1.6307f, -0.35f);
+
         [HarmonyPatch(typeof(RoundManager), "SetExitIDs")]
         [HarmonyPostfix]
         [HarmonyAfter(["x753.Mimics"])]
         private static void AssignInteractTriggerOffset()
         {
-            // The difference between the original fire door and the mimic 
-            var offset = new Vector3(0, 1.6307f, -0.35f);
-            
             foreach (var mimicDoor in MimicDoor.allMimics)
-            {
-                mimicDoor.interactTrigger.gameObject.AddComponent<InteractCanvasPositionOffset>().offset = offset;
-            }
+                mimicDoor.interactTrigger.gameObject.AddComponent<InteractCanvasPositionOffset>().offset = doorInteractorOffset;
         }
     }
 }

--- a/LCVR.csproj
+++ b/LCVR.csproj
@@ -44,6 +44,9 @@
     <Reference Include="MoreCompany">
       <HintPath>Libs\MoreCompany.dll</HintPath>
     </Reference>
+    <Reference Include="Mimics">
+      <HintPath>Libs\Mimics.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.Animation.Rigging">
       <HintPath>Libs\Unity.Animation.Rigging.dll</HintPath>
     </Reference>

--- a/LCVR/Compat.cs
+++ b/LCVR/Compat.cs
@@ -8,6 +8,7 @@ namespace LCVR
         private static readonly CompatibleMod[] ModCompatibilityList =
         [
             new("MoreCompany", "me.swipez.melonloader.morecompany", "1.7.4"),
+            new("Mimics", "x753.Mimics", "2.3.2"),
         ];
 
         private static readonly List<string> DetectedMods = [];

--- a/LCVR/Plugin.cs
+++ b/LCVR/Plugin.cs
@@ -22,8 +22,10 @@ using UnityEngine.XR.OpenXR.Features.Interactions;
 namespace LCVR
 {
     [BepInPlugin(PLUGIN_GUID, PLUGIN_NAME, PLUGIN_VERSION)]
+    #region Compatibility Dependencies
     [BepInDependency("me.swipez.melonloader.morecompany", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("x753.Mimics", BepInDependency.DependencyFlags.SoftDependency)]
+    #endregion
     public class Plugin : BaseUnityPlugin
     {
         public const string PLUGIN_GUID = "io.daxcess.lcvr";

--- a/LCVR/Plugin.cs
+++ b/LCVR/Plugin.cs
@@ -23,6 +23,7 @@ namespace LCVR
 {
     [BepInPlugin(PLUGIN_GUID, PLUGIN_NAME, PLUGIN_VERSION)]
     [BepInDependency("me.swipez.melonloader.morecompany", BepInDependency.DependencyFlags.SoftDependency)]
+    [BepInDependency("x753.Mimics", BepInDependency.DependencyFlags.SoftDependency)]
     public class Plugin : BaseUnityPlugin
     {
         public const string PLUGIN_GUID = "io.daxcess.lcvr";

--- a/Player/VRController.cs
+++ b/Player/VRController.cs
@@ -10,6 +10,7 @@ using LCVR.Input;
 using LCVR.Assets;
 using System.Linq;
 using System.ComponentModel;
+using LCVR.UI;
 
 namespace LCVR.Player
 {
@@ -227,7 +228,14 @@ namespace LCVR.Player
                     hitInteractable = true;
 
                     // Place interaction hud on object
-                    player.hud.UpdateInteractCanvasPosition(hit.transform.position);
+                    var position = hit.transform.position;
+                    var offsetComponent = hit.transform.gameObject.GetComponent<InteractCanvasPositionOffset>();
+                    if (offsetComponent != null)
+                    {
+                        position = hit.transform.TransformPoint(offsetComponent.offset);
+                    }
+                    
+                    player.hud.UpdateInteractCanvasPosition(position);
 
                     if (hit.collider.gameObject.CompareTag("InteractTrigger"))
                     {

--- a/UI/InteractCanvasPositionOffset.cs
+++ b/UI/InteractCanvasPositionOffset.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+namespace LCVR.UI;
+
+public class InteractCanvasPositionOffset : MonoBehaviour
+{
+    public Vector3 offset;
+}


### PR DESCRIPTION
This fixes the Interact UI when interacting with doors from the [Mimics mod](https://github.com/x753/Lethal-Company-Mimics). 

It adds an offset component to all mimic doors with the desired offset. This is then read out right before `UpdateInteractCanvasPosition` is called. 

I've mainly done it this way to not pollute the LCVR code with random mod patches, but it could be simplified by checking if the InteractTrigger's parent object is a mimic door directly in the `VRController` class. This patch might also not be desired in general since having soft dependencies on mods like this can get pretty tedious to maintain.

I would love to hear your opinion on this :)