### PR TITLE
PoC: Await devices on launch (`index` detection fix)

### DIFF
--- a/Input/Actions.cs
+++ b/Input/Actions.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using UnityEngine.InputSystem;
-using UnityEngine.XR.OpenXR.Features.Interactions;
 
 namespace LCVR.Input
 {
@@ -75,36 +74,8 @@ namespace LCVR.Input
 
             foreach (var device in InputSystem.devices)
             {
-                if (device is OculusTouchControllerProfile.OculusTouchController || device is KHRSimpleControllerProfile.KHRSimpleController || device is MetaQuestTouchProControllerProfile.QuestProTouchController)
-                {
-                    // Apply default profile
-                    profile = "default";
+                if (Utils.ToControllerProfile(device, out profile))
                     break;
-                }
-                else if (device is ValveIndexControllerProfile.ValveIndexController)
-                {
-                    // Apply valve index profile
-                    profile = "index";
-                    break;
-                }
-                else if (device is HTCViveControllerProfile.ViveController)
-                {
-                    // Apply HTC vive controller profile
-                    profile = "htc_vive";
-                    break;
-                }
-                else if (device is HPReverbG2ControllerProfile.ReverbG2Controller)
-                {
-                    // Apply HP Reverb G2 controller profile
-                    profile = "hp_reverb";
-                    break;
-                }
-                else if (device is MicrosoftMotionControllerProfile.WMRSpatialController)
-                {
-                    // Apply WMR controller profile
-                    profile = "wmr";
-                    break;
-                }
             }
 
             if (string.IsNullOrEmpty(profile))

--- a/LCVR/Utils.cs
+++ b/LCVR/Utils.cs
@@ -6,6 +6,7 @@ using UnityEngine.Rendering.HighDefinition;
 using System.Collections.Generic;
 using LCVR.Assets;
 using UnityEngine.XR.Interaction.Toolkit;
+using UnityEngine.XR.OpenXR.Features.Interactions;
 using System.Security.Cryptography;
 
 namespace LCVR
@@ -110,6 +111,39 @@ namespace LCVR
             controller.translateAnchorAction = new InputActionProperty(AssetManager.defaultInputActions.FindAction($"{hand}/Translate Anchor"));
             controller.scaleToggleAction = new InputActionProperty(AssetManager.defaultInputActions.FindAction($"{hand}/Scale Toggle"));
             controller.scaleDeltaAction = new InputActionProperty(AssetManager.defaultInputActions.FindAction($"{hand}/Scale Delta"));
+        }
+
+        public static bool ToControllerProfile(InputDevice device, out string profile)
+        {
+            profile = "";
+
+            if (device is OculusTouchControllerProfile.OculusTouchController || device is KHRSimpleControllerProfile.KHRSimpleController || device is MetaQuestTouchProControllerProfile.QuestProTouchController)
+            {
+                // Apply default profile
+                profile = "default";
+            }
+            else if (device is ValveIndexControllerProfile.ValveIndexController)
+            {
+                // Apply valve index profile
+                profile = "index";
+            }
+            else if (device is HTCViveControllerProfile.ViveController)
+            {
+                // Apply HTC vive controller profile
+                profile = "htc_vive";
+            }
+            else if (device is HPReverbG2ControllerProfile.ReverbG2Controller)
+            {
+                // Apply HP Reverb G2 controller profile
+                profile = "hp_reverb";
+            }
+            else if (device is MicrosoftMotionControllerProfile.WMRSpatialController)
+            {
+                // Apply WMR controller profile
+                profile = "wmr";
+            }
+
+            return !string.IsNullOrEmpty(profile);
         }
 
         public static bool BoxCast(this Ray ray, float radius, out RaycastHit hit, float maxDistance = Mathf.Infinity, int layerMask = Physics.DefaultRaycastLayers)


### PR DESCRIPTION
It appears that `InputSystem.devices` may be empty when `Actions` is initialized at the start of LCVR. This is almost always true for Index controllers which causes the profile detection to fail, regardless whether SteamVR is launched.

After playing around with [`InputSystem.onDeviceChange`](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.7/api/UnityEngine.InputSystem.InputSystem.html#UnityEngine_InputSystem_InputSystem_onDeviceChange), it appears that the Index controller devices are added around 1 second (at least on my system) after profile detection is attempted.

I couldn't find a way to properly defer `Actions` initialization so I'm uploading this buggy but functional proof of concept, which simply waits 2 seconds before continuing with VR patching, after which profile detection occurs.

The idea was that maybe I could hook into `onDeviceChange` and wait for a known device or until a timeout (3 sec?) occurs, then continue the initialization right after, but I got lost in the initialization process and the way `onDeviceChange` gets chaotically called.

In any case, there's definitely a simpler and less error-prone way to go about it, so this PR is mostly here to shine some light on the Index issues. I could work on a solution if you have some pointers.

Some loose ideas:
1. Load the profile when the game starts, this would mean stuff like head rotation would use a potentially wrong profile in the main menu, but it doesn't seem to be an issue.
1. Defer initialization in a proper way, wait on a couple of calls to `onDeviceChange` before calling it complete, then continue as soon as devices are added or a short timeout is reached (timeout currently has a race condition explained in code comments).